### PR TITLE
[WIP] feat (backend): 添加场景管理基础功能

### DIFF
--- a/backend/app/api/scenes.py
+++ b/backend/app/api/scenes.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, HTTPException
+from typing import List
+from ..models.scene import Scene
+from ..services.scene_service import get_all_scenes, get_scene
+
+router = APIRouter(prefix="/api/scenes", tags=["scenes"])
+
+@router.get("/", response_model=List[Scene])
+async def list_scenes():
+    """获取所有场景列表"""
+    return get_all_scenes()
+
+@router.get("/{scene_id}", response_model=Scene)
+async def get_scene_by_id(scene_id: str):
+    """获取特定场景详情"""
+    try:
+        return get_scene(scene_id)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) 

--- a/backend/app/models/scene.py
+++ b/backend/app/models/scene.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+from typing import List, Optional
+
+class Scene(BaseModel):
+    id: str
+    title: str
+    description: str
+    difficulty: str  # "beginner", "intermediate", "advanced"
+    estimated_time: int  # 预计完成时间（分钟）
+    tasks: List[str]
+    background: str  # 场景背景描述
+    npc_role: str  # NPC 角色描述
+    learning_objectives: List[str]  # 学习目标 

--- a/backend/app/services/scene_service.py
+++ b/backend/app/services/scene_service.py
@@ -1,0 +1,58 @@
+from typing import List, Dict
+from ..models.scene import Scene
+
+# 示例场景数据
+SCENES: Dict[str, Scene] = {
+    "coffee_shop": Scene(
+        id="coffee_shop",
+        title="咖啡店点餐",
+        description="在咖啡店与服务员进行点餐对话",
+        difficulty="beginner",
+        estimated_time=15,
+        tasks=[
+            "向服务员问候并表达想要点餐的意图",
+            "询问菜单推荐",
+            "选择饮品并说明具体要求",
+            "选择小点心",
+            "确认订单并付款"
+        ],
+        background="你正在一家美式咖啡店，需要点一杯咖啡和一份小点心。",
+        npc_role="你是一位友好的咖啡店服务员，会帮助顾客点餐并提供建议。",
+        learning_objectives=[
+            "掌握基本的点餐用语",
+            "学习如何询问和表达偏好",
+            "练习礼貌用语和日常对话"
+        ]
+    ),
+    "restaurant": Scene(
+        id="restaurant",
+        title="餐厅用餐",
+        description="在餐厅与服务员进行点餐和用餐对话",
+        difficulty="intermediate",
+        estimated_time=20,
+        tasks=[
+            "预订座位",
+            "查看菜单并询问推荐",
+            "点餐并说明特殊要求",
+            "处理用餐过程中的问题",
+            "结账并给小费"
+        ],
+        background="你正在一家高档餐厅用餐，需要与服务员进行完整的用餐体验对话。",
+        npc_role="你是一位专业的餐厅服务员，熟悉菜单并能提供专业的建议。",
+        learning_objectives=[
+            "掌握餐厅用餐相关词汇",
+            "学习如何表达特殊饮食需求",
+            "练习处理用餐过程中的问题"
+        ]
+    )
+}
+
+def get_all_scenes() -> List[Scene]:
+    """获取所有场景列表"""
+    return list(SCENES.values())
+
+def get_scene(scene_id: str) -> Scene:
+    """获取特定场景详情"""
+    if scene_id not in SCENES:
+        raise ValueError(f"Scene {scene_id} not found")
+    return SCENES[scene_id] 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,21 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from app.api import scenes
+
+app = FastAPI(title="LanguageVoyage API")
+
+# 配置 CORS
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # 在开发环境中允许所有来源
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# 注册路由
+app.include_router(scenes.router)
+
+@app.get("/")
+async def root():
+    return {"message": "Welcome to LanguageVoyage API"} 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,13 +1,9 @@
 fastapi==0.109.2
 uvicorn==0.27.1
-sqlalchemy==2.0.27
 pydantic==2.6.1
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
-python-multipart==0.0.6
-langchain==0.1.4
 python-dotenv==1.0.1
 pytest==8.0.1
 httpx==0.26.0
-alembic==1.13.1
-psycopg2-binary==2.9.9 
+openai==1.12.0 


### PR DESCRIPTION
# [WIP] 场景管理基础功能实现

## 描述
这个PR实现了语言学习场景的基础功能，包括场景数据结构和基本API接口。目前使用简单的内存数据存储，方便测试和演示。

## 当前实现
- [x] 定义了场景数据结构（包含标题、描述、难度等）
- [x] 添加了两个示例场景（咖啡店点餐和餐厅用餐）
- [x] 实现了获取场景列表和场景详情的API

## 待实现功能
1. 数据存储
   - [ ] 添加数据库
   - [ ] 添加更多示例场景

2. 场景功能扩展
   - [ ] 添加场景的中英文对照
   - [ ] 添加更多的对话提示和例句
   - [ ] 补充场景相关的词汇表

## 测试方法
1. 启动服务器后访问 `/api/scenes` 可以看到所有场景列表
2. 访问 `/api/scenes/coffee_shop` 可以查看咖啡店场景的详细信息

## 注意事项
- 现在的数据是直接写在代码里的，后面会改成从文件读取
- 场景内容还需要补充和完善

请不要合并这个PR，后面还要添加更多场景内容和功能。